### PR TITLE
VE flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,9 @@
 --------------------------------------------------------------------------------
 👉 OpenMoji 12.X - XXX
 
+* Fix 1F1FB-1F1EA by Jonathan Dixon @jonpdixon
+  Correct colour order and number of stars on Venezuelan flag
+  
 + Added Youtube and Github logo, contributed by Romain Bazile @gromain
 
 * Fix 1F3F4-E0067-E0062-E0073-E0063-E0074-E007F by Carlin Mackenzie @carlinmack

--- a/src/flags/country-flag/1F1FB-1F1EA.svg
+++ b/src/flags/country-flag/1F1FB-1F1EA.svg
@@ -7,17 +7,18 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <rect x="5" y="17" width="62" height="38" fill="#1e50a0"/>
+    <rect x="5" y="17" width="62" height="38" fill="#d22f27"/>
     <rect x="5" y="17" width="62" height="13" fill="#f1b31c"/>
-    <rect x="5" y="30" width="62" height="12" fill="#d22f27"/>
+    <rect x="5" y="30" width="62" height="12" fill="#1e50a0"/>
     <g>
-      <circle cx="36" cy="33" r="1" fill="#fff"/>
-      <circle cx="32" cy="34" r="1" fill="#fff"/>
-      <circle cx="29" cy="36" r="1" fill="#fff"/>
-      <circle cx="27" cy="39" r="1" fill="#fff"/>
-      <circle cx="40" cy="34" r="1" fill="#fff"/>
-      <circle cx="43" cy="36" r="1" fill="#fff"/>
-      <circle cx="45" cy="39" r="1" fill="#fff"/>
+      <circle cx="34" cy="33" r="1" fill="#fff"/>
+      <circle cx="38" cy="33" r="1" fill="#fff"/>
+      <circle cx="30" cy="34" r="1" fill="#fff"/>
+      <circle cx="27" cy="36" r="1" fill="#fff"/>
+      <circle cx="25" cy="39" r="1" fill="#fff"/>
+      <circle cx="42" cy="34" r="1" fill="#fff"/>
+      <circle cx="45" cy="36" r="1" fill="#fff"/>
+      <circle cx="47" cy="39" r="1" fill="#fff"/>
     </g>
   </g>
   <g id="line">


### PR DESCRIPTION
Corrected Venezuelan flag 1F1FB-1F1EA changing colour order and 8 stars instead of 7.