### PR TITLE
Add test for duplicate attributes

### DIFF
--- a/test/file-format.js
+++ b/test/file-format.js
@@ -5,7 +5,7 @@ const argv = require('optimist').demand('openmoji-data-json').argv;
 const openmojiDataJson = argv['openmoji-data-json'];
 const openmojis = require(openmojiDataJson);
 
-const { createDoc } = require('./utils/utils');
+const { createDoc, readSVG } = require('./utils/utils');
 
 
 describe('OpenMoji file format', function() {
@@ -70,5 +70,32 @@ describe('OpenMoji file format', function() {
       });
     });
   });
+
+  describe('Top level <g> elements have IDs?', function () {
+      emojis.forEach(emoji => {
+          it(`${emoji.emoji} ${emoji.hexcode}.svg top level <g> should have IDs`, function () {
+              const doc = createDoc(emoji);
+              const groups = doc.querySelectorAll('svg > g');
+              const idGroups = doc.querySelectorAll('svg > g[id]');
+              expect(groups.length).to.equal(idGroups.length);
+          });
+      });
+  });
+
+  describe('Elements should not have duplicate attributes', function () {
+      emojis.forEach(emoji => {
+          it(`${emoji.emoji} ${emoji.hexcode}.svg elements should not have duplicate attributes`, function () {
+              const doc = readSVG(emoji);
+              let elements = doc.match(/<\w.*>/g);
+
+              elements.forEach(element => {
+                  const attrs = element.match(/((\w|-)+)=/g);
+                  const dedupeAttrs = new Set(attrs);
+                  if (attrs) expect(attrs.length).to.equal(dedupeAttrs.size);
+              });
+          });
+      });
+  });
+
 
 });

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -12,9 +12,16 @@ function createDoc(emoji) {
   return dom.window.document;
 }
 
+function readSVG(emoji) {
+    const svgFile = path.join(openmojiSrcFolder, emoji.group, emoji.subgroups, emoji.hexcode + '.svg');
+    var str = fs.readFileSync(svgFile, "utf8");
+    return str;
+}
+
 function getSrcFilepath(emoji) {
   return path.join(openmojiSrcFolder, emoji.group, emoji.subgroups, emoji.hexcode + '.svg');
 }
 
-module.exports.getSrcFilepath = getSrcFilepath;
 module.exports.createDoc = createDoc;
+module.exports.readSVG = readSVG;
+module.exports.getSrcFilepath = getSrcFilepath;


### PR DESCRIPTION
Can't use the JSDOM version of the svg as it trims duplicate attributes, so I added a utility function to read the file to a string. Have to regex for the elements and then regex for the attributes. All existing emoji pass these tests

Test required due to #74 