### PR TITLE
initial commit figma cleanup script

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -63,6 +63,7 @@ Fix:
 Tech:
   * Blazing fast new build system by Kris Kowal @kriskowal
   * OpenMoji Black/Colorfont scale up by 1.3 to match emoji size of other vendors
+  * New cleanup script for figma svg export
 
 --------------------------------------------------------------------------------
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -31,6 +31,7 @@ This folder `helpers/` Contains various helper scripts e.g. to export to .png an
 - `generate-index-html.js` generate overview grid index.html
 - `generate-index-list-html.js` generate overview list index-list.html
 - `import-svg-to-src-folder.js` import new OpenMojis to src folder
+- `prettyfy-figma-svg.js` prettfy svg files exported by [Figma](https://www.figma.com/)
 
 
 

--- a/helpers/prettyfy-figma-svg.js
+++ b/helpers/prettyfy-figma-svg.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+const chroma = require('chroma-js');
+const KDTree = require('kd-tree-javascript').kdTree;
+const JSDOM = require('jsdom').JSDOM;
+
+
+const writeSvg = (filePath, data) => {
+  fs.writeFileSync(filePath, data);
+}
+
+const prettyfyFigmaSVG = (srcFilePath, destFilePath) => {
+  const dom = new JSDOM(fs.readFileSync(srcFilePath, 'utf8'));
+  const doc = dom.window.document;
+  let modified = false;
+
+  // Problem: figma will add a `fill="none"` attribute to the svg element. all child elements will implicitly be set to `fill="none"`. we instead want svg's default behaivior
+
+  const svgWithFillNone = doc.querySelector('svg[fill="none"]');
+  if (svgWithFillNone) {
+    svgWithFillNone.removeAttribute('fill');
+    const elementsWithoutFill = svgWithFillNone.querySelectorAll('circle:not([fill]), ellipse:not([fill]), path:not([fill]), polygon:not([fill]), polyline:not([fill]), rect:not([fill])')
+    elementsWithoutFill.forEach(el => {
+      el.setAttribute('fill', 'none');
+    });
+
+    modified = true;
+  }
+
+  // Problem: figma will automatically add ids based on the type of element. 
+
+  const figmaDefaultIds = ['Rectangle', 'Vector', 'Line', 'Arrow', 'Ellipse', 'Star', 'Polygon', 'Union', 'Subtract', 'Intersect', 'Exclude', 'Group'];
+  const elementsWithId = doc.querySelectorAll('[id^="' + figmaDefaultIds.join('"], [id^="') + '"]');
+  elementsWithId.forEach(el => {
+    el.removeAttribute('id');
+    modified = true;
+  });
+
+  // Problem: figma will create a root element `g` with an id that is equal to the artboard name
+
+  const rootGroup = doc.querySelector('svg > g[id]:only-child');
+  if (rootGroup) {
+    let parent = rootGroup.parentNode;
+    while (rootGroup.firstChild) parent.insertBefore(rootGroup.firstChild, rootGroup);
+    parent.removeChild(rootGroup);
+    modified = true;
+  }
+
+  if (modified) {
+    console.log('cleaning up -> ', srcFilePath);
+  }
+  fs.unlinkSync(srcFilePath);
+  writeSvg(destFilePath, doc.querySelector('svg').outerHTML);
+}
+
+function searchDirectoryForFigma(startPath) {
+  let files = fs.readdirSync(startPath);
+  for(let i = 0; i < files.length; i++){
+    let filename = path.join(startPath,files[i]);
+    let stat = fs.lstatSync(filename);
+    if (stat.isDirectory()){
+       searchDirectoryForFigma(filename);
+    }
+    else if (filename.indexOf('.figma.svg') >= 0) {
+      prettyfyFigmaSVG(filename, filename.replace('.figma.svg', '.svg'));
+    };
+  };
+};
+
+searchDirectoryForFigma('./src');


### PR DESCRIPTION
refs #196 , @b-g

## How to test

1. open this file in figma:  
   [https://www.figma.com/file/sZZLEmdnMTOAxq0mTgO4WN/new-openmoji?node-id=169%3A0](new-openmoji.figma)
2. export the frame using these settings:  
  ![figma-export](https://user-images.githubusercontent.com/842548/80803288-23d7b480-8bb2-11ea-871a-9d3a0277aa4b.png)
3. choose any directory in `./src`
4. run `node helpers/prettyfy-figma-svg.js`

## Expect

1. running `node helpers/prettyfy-figma-svg.js` should remove the `.figma` interfix.
![interfix removed](https://user-images.githubusercontent.com/842548/80803484-b24c3600-8bb2-11ea-961c-9d2e3eb827dd.png)
2. The following changes should have been applied to the svg:
    1. remove `fill="none"` attribute from the svg element. Elements without fill should have a `fill="none"` attribute.
    2. no element should have a figma default id (like `Rectangle 4`,  `Vector 7` etc…)
    3. remove root `<g>` element