### PR TITLE
Standardise subfamily names

### DIFF
--- a/font/scfbuild-black.yml
+++ b/font/scfbuild-black.yml
@@ -11,9 +11,9 @@ width_space: 561
 table_name:
   version: 12.2.0
   copyright: OpenMoji © HfG Schwäbisch Gmünd CC-BY-SA-4.0
-  family: OpenMoji
+  family: OpenMoji Black
   # Subfamily is also called Style or Weight. Often set to: Regular
-  subfamily: Black
+  subfamily: Regular
   unique_id: OpenMoji Black openmoji.org
   full_name: OpenMoji Black
   # No spaces in PostScript Names

--- a/font/scfbuild-black.yml
+++ b/font/scfbuild-black.yml
@@ -11,9 +11,9 @@ width_space: 561
 table_name:
   version: 12.2.0
   copyright: OpenMoji © HfG Schwäbisch Gmünd CC-BY-SA-4.0
-  family: OpenMoji Black
+  family: OpenMoji
   # Subfamily is also called Style or Weight. Often set to: Regular
-  subfamily: Regular
+  subfamily: Black
   unique_id: OpenMoji Black openmoji.org
   full_name: OpenMoji Black
   # No spaces in PostScript Names
@@ -29,3 +29,7 @@ table_name:
   url_designer: http://openmoji.org/about.html
   license: Creative Commons Share Alike 4.0
   url_license: https://creativecommons.org/licenses/by-sa/4.0/
+  typographic_family: OpenMoji
+  typographic_subfamily: Black
+  wws_family: OpenMoji Black
+  wws_subfamily: Regular

--- a/font/scfbuild-color.yml
+++ b/font/scfbuild-color.yml
@@ -11,9 +11,9 @@ width_space: 561
 table_name:
   version: 12.2.0
   copyright: OpenMoji © HfG Schwäbisch Gmünd CC-BY-SA-4.0
-  family: OpenMoji Color
+  family: OpenMoji
   # Subfamily is also called Style or Weight. Often set to: Regular
-  subfamily: Regular
+  subfamily: Color
   unique_id: OpenMoji Color openmoji.org
   full_name: OpenMoji Color
   # No spaces in PostScript Names
@@ -29,3 +29,7 @@ table_name:
   url_designer: http://openmoji.org/about.html
   license: Creative Commons Share Alike 4.0
   url_license: https://creativecommons.org/licenses/by-sa/4.0/
+  typographic_family: OpenMoji
+  typographic_subfamily: Color
+  wws_family: OpenMoji Color
+  wws_subfamily: Regular

--- a/font/scfbuild-color.yml
+++ b/font/scfbuild-color.yml
@@ -11,9 +11,9 @@ width_space: 561
 table_name:
   version: 12.2.0
   copyright: OpenMoji © HfG Schwäbisch Gmünd CC-BY-SA-4.0
-  family: OpenMoji
+  family: OpenMoji Color
   # Subfamily is also called Style or Weight. Often set to: Regular
-  subfamily: Color
+  subfamily: Regular
   unique_id: OpenMoji Color openmoji.org
   full_name: OpenMoji Color
   # No spaces in PostScript Names


### PR DESCRIPTION
It’s [strongly recommended][1] that `subfamily` be one of the four basic
styles, “regular”, “italic”, “bold”, “bold italic”.  Hence, “Color” and
“Black” should be part of the `family`, not the `subfamily`.

[1]: https://docs.microsoft.com/en-us/typography/opentype/spec/name#name-ids