### PR TITLE
initial attempt to fix #31

### DIFF
--- a/helpers/add-background.js
+++ b/helpers/add-background.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const openmojis = require("../data/openmoji.json");
+
+const {
+    createDoc
+} = require('../test/utils/utils');
+
+const directory = 'srctemp/';
+console.log('doing stuff')
+openmojis.forEach(emoji => {
+    const svgFile = path.join("src", emoji.group, emoji.subgroups, emoji.hexcode + '.svg')
+    const doc = createDoc(emoji);
+
+    const root = doc.querySelector("#emoji")
+
+    const backgroundGroup = doc.createElement('g')
+    backgroundGroup.setAttribute('id', "background")
+    backgroundGroup.setAttribute('xmlns', "http://www.w3.org/2000/svg")
+
+    const beforeNode = doc.querySelector("#grid").nextSibling
+    root.insertBefore(backgroundGroup, beforeNode)
+
+    const lineLayer = doc.querySelector("#line")
+
+    const supplementLayer = doc.querySelector("#line-supplement")
+
+    const lineDup = lineLayer.cloneNode(true)
+
+    while (lineDup.children.length) {
+        lineDup.children[0].setAttribute('stroke-width', "6")
+        lineDup.children[0].setAttribute('stroke', "#fff")
+        backgroundGroup.appendChild(lineDup.firstChild);
+    }
+
+    if (supplementLayer) {
+        const supplementDup = supplementLayer.cloneNode(true)
+
+        while (supplementDup.children.length) {
+            supplementDup.children[0].setAttribute('stroke-width', "6")
+            supplementDup.children[0].setAttribute('stroke', "#fff")
+            backgroundGroup.appendChild(supplementDup.firstChild);
+        }
+    }
+
+    fs.writeFile(svgFile, doc.documentElement.querySelector("svg").outerHTML, function (err) {
+        if (err) return console.log(err);
+        console.log('Successful');
+    });
+})

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "generate": "./helpers/generate.sh",
     "generate-font": "./helpers/generate-fonts.sh",
     "cache-clear": "for ref in export-png-618 export-png-72 export-svg-color export-svg-skintones pretty-src-svg; do git update-ref -d refs/memos/$ref; done",
-    "cc": "npm run cache-clear"
+    "cc": "npm run cache-clear",
+    "add-background": "node helpers/add-background.js --openmoji-src-folder $PWD/src"
   },
   "engines": {
     "node": "8.x"

--- a/src/activities/event/1F38D.svg
+++ b/src/activities/event/1F38D.svg
@@ -1,67 +1,93 @@
 <svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
   <g id="grid">
-    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72V0Z"/>
-    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352V12.8813A1.923,1.923,0,0,1,12.923,10.9583Z"/>
-    <rect x="16" y="4" rx="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="16" y="4" rx="2.2537" width="40" height="64" transform="translate(72) rotate(90)" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-  </g>
+    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72V0Z"></path>
+    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352V12.8813A1.923,1.923,0,0,1,12.923,10.9583Z"></path>
+    <rect x="16" y="4" rx="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"></rect>
+    <rect x="16" y="4" rx="2.2537" width="40" height="64" transform="translate(72) rotate(90)" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"></rect>
+    <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"></circle>
+  </g><g id="background" xmlns="http://www.w3.org/2000/svg">
+    <rect x="26" y="56" width="20" height="11" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"></rect>
+    <line x1="22.7071" x2="31.8995" y1="46.7071" y2="55.8995" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="29.0711" x2="29.0711" y1="48.8284" y2="53.0711" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="26.2426" x2="26.2426" y1="46" y2="50.2426" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="24.8284" x2="29.0711" y1="53.0711" y2="53.0711" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="22" x2="26.2426" y1="50.2426" y2="50.2426" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="49.2929" x2="40.1005" y1="46.7071" y2="55.8995" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="42.9289" x2="42.9289" y1="48.8284" y2="53.0711" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="45.7574" x2="45.7574" y1="46" y2="50.2426" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="47.1716" x2="42.9289" y1="53.0711" y2="53.0711" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="50" x2="45.7574" y1="50.2426" y2="50.2426" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="36" x2="36" y1="43" y2="56" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="33" x2="36" y1="49" y2="52" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="33" x2="36" y1="45" y2="48" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="39" x2="36" y1="49" y2="52" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="39" x2="36" y1="45" y2="48" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="35" x2="35" y1="22" y2="33" fill="none" stroke="#fff" stroke-linecap="round" stroke-miterlimit="10" stroke-width="6"></line>
+    <line x1="37" x2="37" y1="28" y2="39" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"></line>
+    <path d="M36.5,8C37.8807,8,39,9.7909,39,12s-1.1193,4-2.5,4S34,14.2091,34,12s1.1193-4,2.5-4m0-2C33.9766,6,32,8.6355,32,12s1.9766,6,4.5,6S41,15.3645,41,12s-1.9766-6-4.5-6Z" stroke-width="6" stroke="#fff"></path>
+    <path d="M40.5,24c1.3807,0,2.5,1.7909,2.5,4s-1.1193,4-2.5,4S38,30.2091,38,28s1.1193-4,2.5-4m0-2c-2.5234,0-4.5,2.6355-4.5,6s1.9766,6,4.5,6S45,31.3645,45,28s-1.9766-6-4.5-6Z" stroke-width="6" stroke="#fff"></path>
+    <path d="M31.5,18c1.3807,0,2.5,1.7909,2.5,4s-1.1193,4-2.5,4S29,24.2091,29,22s1.1193-4,2.5-4m0-2c-2.5234,0-4.5,2.6355-4.5,6s1.9766,6,4.5,6S36,25.3645,36,22s-1.9766-6-4.5-6Z" stroke-width="6" stroke="#fff"></path>
+    <path d="M36.5,8C37.8807,8,39,9.7908,39,12V24.8181A1.9823,1.9823,0,0,1,40.5,24c1.3807,0,2.5,1.7908,2.5,4V55H29V22c0-2.2092,1.1193-4,2.5-4S34,19.7908,34,22l.08-10c0-2.2092,1.039-4,2.42-4m0-2c-2.52,0-4.42,2.5794-4.42,6l-.0325,4.0421A3.5721,3.5721,0,0,0,31.5,16c-2.5234,0-4.5,2.6355-4.5,6V55a2,2,0,0,0,2,2H43a2,2,0,0,0,2-2V28c0-3.1388-1.72-5.6432-4-5.965V12c0-3.3645-1.9766-6-4.5-6Z" stroke-width="6" stroke="#fff"></path>
+    <line x1="32" x2="32" y1="56" y2="67" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"></line>
+    <line x1="40" x2="40" y1="56" y2="67" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"></line>
+    <line x1="46" x2="26" y1="59.5" y2="59.5" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"></line>
+    <line x1="26" x2="46" y1="63.5" y2="63.5" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="6"></line></g>
   <g id="line-supplement">
-    <line x1="22.7071" x2="31.8995" y1="46.7071" y2="55.8995" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="29.0711" x2="29.0711" y1="48.8284" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="26.2426" x2="26.2426" y1="46" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="24.8284" x2="29.0711" y1="53.0711" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="22" x2="26.2426" y1="50.2426" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="49.2929" x2="40.1005" y1="46.7071" y2="55.8995" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="42.9289" x2="42.9289" y1="48.8284" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="45.7574" x2="45.7574" y1="46" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="47.1716" x2="42.9289" y1="53.0711" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="50" x2="45.7574" y1="50.2426" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="36" x2="36" y1="43" y2="56" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="33" x2="36" y1="49" y2="52" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="33" x2="36" y1="45" y2="48" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="39" x2="36" y1="49" y2="52" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="39" x2="36" y1="45" y2="48" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="35" x2="35" y1="22" y2="33" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="37" x2="37" y1="28" y2="39" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <path d="M36.5,8C37.8807,8,39,9.7909,39,12s-1.1193,4-2.5,4S34,14.2091,34,12s1.1193-4,2.5-4m0-2C33.9766,6,32,8.6355,32,12s1.9766,6,4.5,6S41,15.3645,41,12s-1.9766-6-4.5-6Z"/>
-    <path d="M40.5,24c1.3807,0,2.5,1.7909,2.5,4s-1.1193,4-2.5,4S38,30.2091,38,28s1.1193-4,2.5-4m0-2c-2.5234,0-4.5,2.6355-4.5,6s1.9766,6,4.5,6S45,31.3645,45,28s-1.9766-6-4.5-6Z"/>
-    <path d="M31.5,18c1.3807,0,2.5,1.7909,2.5,4s-1.1193,4-2.5,4S29,24.2091,29,22s1.1193-4,2.5-4m0-2c-2.5234,0-4.5,2.6355-4.5,6s1.9766,6,4.5,6S36,25.3645,36,22s-1.9766-6-4.5-6Z"/>
-    <path d="M36.5,8C37.8807,8,39,9.7908,39,12V24.8181A1.9823,1.9823,0,0,1,40.5,24c1.3807,0,2.5,1.7908,2.5,4V55H29V22c0-2.2092,1.1193-4,2.5-4S34,19.7908,34,22l.08-10c0-2.2092,1.039-4,2.42-4m0-2c-2.52,0-4.42,2.5794-4.42,6l-.0325,4.0421A3.5721,3.5721,0,0,0,31.5,16c-2.5234,0-4.5,2.6355-4.5,6V55a2,2,0,0,0,2,2H43a2,2,0,0,0,2-2V28c0-3.1388-1.72-5.6432-4-5.965V12c0-3.3645-1.9766-6-4.5-6Z"/>
-    <line x1="32" x2="32" y1="56" y2="67" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line x1="40" x2="40" y1="56" y2="67" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line x1="46" x2="26" y1="59.5" y2="59.5" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line x1="26" x2="46" y1="63.5" y2="63.5" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <line x1="22.7071" x2="31.8995" y1="46.7071" y2="55.8995" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="29.0711" x2="29.0711" y1="48.8284" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="26.2426" x2="26.2426" y1="46" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="24.8284" x2="29.0711" y1="53.0711" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="22" x2="26.2426" y1="50.2426" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="49.2929" x2="40.1005" y1="46.7071" y2="55.8995" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="42.9289" x2="42.9289" y1="48.8284" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="45.7574" x2="45.7574" y1="46" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="47.1716" x2="42.9289" y1="53.0711" y2="53.0711" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="50" x2="45.7574" y1="50.2426" y2="50.2426" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="36" x2="36" y1="43" y2="56" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="33" x2="36" y1="49" y2="52" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="33" x2="36" y1="45" y2="48" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="39" x2="36" y1="49" y2="52" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="39" x2="36" y1="45" y2="48" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="35" x2="35" y1="22" y2="33" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="37" x2="37" y1="28" y2="39" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <path d="M36.5,8C37.8807,8,39,9.7909,39,12s-1.1193,4-2.5,4S34,14.2091,34,12s1.1193-4,2.5-4m0-2C33.9766,6,32,8.6355,32,12s1.9766,6,4.5,6S41,15.3645,41,12s-1.9766-6-4.5-6Z"></path>
+    <path d="M40.5,24c1.3807,0,2.5,1.7909,2.5,4s-1.1193,4-2.5,4S38,30.2091,38,28s1.1193-4,2.5-4m0-2c-2.5234,0-4.5,2.6355-4.5,6s1.9766,6,4.5,6S45,31.3645,45,28s-1.9766-6-4.5-6Z"></path>
+    <path d="M31.5,18c1.3807,0,2.5,1.7909,2.5,4s-1.1193,4-2.5,4S29,24.2091,29,22s1.1193-4,2.5-4m0-2c-2.5234,0-4.5,2.6355-4.5,6s1.9766,6,4.5,6S36,25.3645,36,22s-1.9766-6-4.5-6Z"></path>
+    <path d="M36.5,8C37.8807,8,39,9.7908,39,12V24.8181A1.9823,1.9823,0,0,1,40.5,24c1.3807,0,2.5,1.7908,2.5,4V55H29V22c0-2.2092,1.1193-4,2.5-4S34,19.7908,34,22l.08-10c0-2.2092,1.039-4,2.42-4m0-2c-2.52,0-4.42,2.5794-4.42,6l-.0325,4.0421A3.5721,3.5721,0,0,0,31.5,16c-2.5234,0-4.5,2.6355-4.5,6V55a2,2,0,0,0,2,2H43a2,2,0,0,0,2-2V28c0-3.1388-1.72-5.6432-4-5.965V12c0-3.3645-1.9766-6-4.5-6Z"></path>
+    <line x1="32" x2="32" y1="56" y2="67" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <line x1="40" x2="40" y1="56" y2="67" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <line x1="46" x2="26" y1="59.5" y2="59.5" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <line x1="26" x2="46" y1="63.5" y2="63.5" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
   </g>
   <g id="color">
-    <rect x="26" y="56" width="20" height="11" fill="#f4aa41"/>
-    <line x1="32" x2="32" y1="56" y2="67" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line x1="40" x2="40" y1="56" y2="67" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line x1="46" x2="26" y1="59.5" y2="59.5" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <line x1="26" x2="46" y1="63.5" y2="63.5" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
-    <rect x="29" y="22" width="5" height="33" fill="#b1cc33"/>
-    <rect x="34" y="12" width="5" height="43" fill="#5c9e31"/>
-    <rect x="38" y="28" width="5" height="27" fill="#b1cc33"/>
-    <ellipse cx="36.5" cy="12" rx="2.5" ry="4" fill="#f4aa41"/>
-    <ellipse cx="40.5" cy="28" rx="2.5" ry="4" fill="#f4aa41"/>
-    <ellipse cx="31.5" cy="22" rx="2.5" ry="4" fill="#f4aa41"/>
-    <line x1="22.7071" x2="31.8995" y1="46.7071" y2="55.8995" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="29.0711" x2="29.0711" y1="48.8284" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="26.2426" x2="26.2426" y1="46" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="24.8284" x2="29.0711" y1="53.0711" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="22" x2="26.2426" y1="50.2426" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="49.2929" x2="40.1005" y1="46.7071" y2="55.8995" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="42.9289" x2="42.9289" y1="48.8284" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="45.7574" x2="45.7574" y1="46" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="47.1716" x2="42.9289" y1="53.0711" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="50" x2="45.7574" y1="50.2426" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="36" x2="36" y1="43" y2="56" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="33" x2="36" y1="49" y2="52" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="33" x2="36" y1="45" y2="48" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="39" x2="36" y1="49" y2="52" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="39" x2="36" y1="45" y2="48" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
+    <rect x="26" y="56" width="20" height="11" fill="#f4aa41"></rect>
+    <line x1="32" x2="32" y1="56" y2="67" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <line x1="40" x2="40" y1="56" y2="67" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <line x1="46" x2="26" y1="59.5" y2="59.5" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <line x1="26" x2="46" y1="63.5" y2="63.5" fill="none" stroke="#a57939" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></line>
+    <rect x="29" y="22" width="5" height="33" fill="#b1cc33"></rect>
+    <rect x="34" y="12" width="5" height="43" fill="#5c9e31"></rect>
+    <rect x="38" y="28" width="5" height="27" fill="#b1cc33"></rect>
+    <ellipse cx="36.5" cy="12" rx="2.5" ry="4" fill="#f4aa41"></ellipse>
+    <ellipse cx="40.5" cy="28" rx="2.5" ry="4" fill="#f4aa41"></ellipse>
+    <ellipse cx="31.5" cy="22" rx="2.5" ry="4" fill="#f4aa41"></ellipse>
+    <line x1="22.7071" x2="31.8995" y1="46.7071" y2="55.8995" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="29.0711" x2="29.0711" y1="48.8284" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="26.2426" x2="26.2426" y1="46" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="24.8284" x2="29.0711" y1="53.0711" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="22" x2="26.2426" y1="50.2426" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="49.2929" x2="40.1005" y1="46.7071" y2="55.8995" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="42.9289" x2="42.9289" y1="48.8284" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="45.7574" x2="45.7574" y1="46" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="47.1716" x2="42.9289" y1="53.0711" y2="53.0711" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="50" x2="45.7574" y1="50.2426" y2="50.2426" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="36" x2="36" y1="43" y2="56" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="33" x2="36" y1="49" y2="52" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="33" x2="36" y1="45" y2="48" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="39" x2="36" y1="49" y2="52" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
+    <line x1="39" x2="36" y1="45" y2="48" fill="none" stroke="#186648" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"></line>
   </g>
   <g id="line">
-    <rect x="26" y="56" width="20" height="11" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect x="26" y="56" width="20" height="11" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"></rect>
   </g>
 </svg>


### PR DESCRIPTION
Works fairly well but:

1. doesn't work on nested groups 
1. changes all the line endings to be </line> instead of using self closing tags

We could fix the first one by mandating that all emoji must be flat and adding a test, or by being more careful when adding attributes to children. 

I'm not too sure how to fix the second one, JSDOM doesn't seem to have much documentation.

To test, I highly recommend deleting everything but the emoji you want to generate from openmoji.json. For example, the emoji in this PR was generated with the following openmoji.json:

```javascript
[{
    "emoji": "🎍",
    "hexcode": "1F38D",
    "group": "activities",
    "subgroups": "event",
    "annotation": "pine decoration",
    "tags": "bamboo, celebration, japanese, pine",
    "openmoji_tags": "",
    "openmoji_author": "Jonas Dunkel",
    "openmoji_date": "2019-05-07",
    "skintone": "",
    "skintone_combination": "",
    "skintone_base_emoji": "",
    "skintone_base_hexcode": "",
    "unicode": 0.6,
    "order": 3209
}]
```