### PR TITLE
fix(🇹🇼): white sun and rays

### DIFF
--- a/src/flags/country-flag/1F1F9-1F1FC.svg
+++ b/src/flags/country-flag/1F1F9-1F1FC.svg
@@ -1,17 +1,18 @@
-<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+<svg id="emoji" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
   <g id="grid">
-    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72V0Z"/>
-    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352V12.8813A1.923,1.923,0,0,1,12.923,10.9583Z"/>
-    <rect x="16" y="4" rx="2.2537" ry="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="16" y="4" rx="2.2537" ry="2.2537" width="40" height="64" transform="translate(72) rotate(90)" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <path d="M68,4V68H4V4H68m4-4H0V72H72Z" fill="#b3b3b3"/>
+    <path d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814h0V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352h0V12.8813a1.9231,1.9231,0,0,1,1.923-1.923Z" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="16" y="4" width="40" height="64" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="4" y="16" width="64" height="40" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
     <rect x="5" y="17" width="62" height="38" fill="#d22f27"/>
     <rect x="5.0009" y="17.0014" width="31.9982" height="19.9971" fill="#1e50a0"/>
-    <polygon fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" points="21.296 25.896 23 23.536 21.808 26.192 24.464 25 22.104 26.704 25 27 22.104 27.296 24.464 29 21.808 27.808 23 30.464 21.296 28.104 21 31 20.704 28.104 19 30.464 20.192 27.808 17.536 29 19.896 27.296 17 27 19.896 26.704 17.536 25 20.192 26.192 19 23.536 20.704 25.896 21 23 21.296 25.896"/>
+    <polygon points="19.523 25.523 18.324 21.999 20.776 24.8 21.5 21.148 22.223 24.8 24.675 21.999 23.476 25.523 27 24.323 24.199 26.776 27.851 27.499 24.199 28.223 27 30.675 23.476 29.475 24.675 33 22.223 30.199 21.5 33.851 20.776 30.199 18.324 33 19.523 29.475 15.999 30.675 18.8 28.223 15.148 27.499 18.8 26.776 15.999 24.323 19.523 25.523" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="21.4995" cy="27.4992" r="4.0888" fill="none" stroke="#1e50a0" stroke-miterlimit="10"/>
   </g>
   <g id="line">
-    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect x="5" y="17" width="62" height="38" stroke-width="2" stroke="#000" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   </g>
 </svg>

--- a/src/flags/country-flag/1F1F9-1F1FC.svg
+++ b/src/flags/country-flag/1F1F9-1F1FC.svg
@@ -1,18 +1,18 @@
-<svg id="emoji" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
   <g id="grid">
-    <path d="M68,4V68H4V4H68m4-4H0V72H72Z" fill="#b3b3b3"/>
-    <path d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814h0V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352h0V12.8813a1.9231,1.9231,0,0,1,1.923-1.923Z" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="16" y="4" width="40" height="64" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="4" y="16" width="64" height="40" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72Z"/>
+    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814h0V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352h0V12.8813a1.9231,1.9231,0,0,1,1.923-1.923Z"/>
+    <rect x="16" y="4" rx="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="4" y="16" rx="2.2537" width="64" height="40" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
     <rect x="5" y="17" width="62" height="38" fill="#d22f27"/>
     <rect x="5.0009" y="17.0014" width="31.9982" height="19.9971" fill="#1e50a0"/>
-    <polygon points="19.523 25.523 18.324 21.999 20.776 24.8 21.5 21.148 22.223 24.8 24.675 21.999 23.476 25.523 27 24.323 24.199 26.776 27.851 27.499 24.199 28.223 27 30.675 23.476 29.475 24.675 33 22.223 30.199 21.5 33.851 20.776 30.199 18.324 33 19.523 29.475 15.999 30.675 18.8 28.223 15.148 27.499 18.8 26.776 15.999 24.323 19.523 25.523" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round"/>
+    <polygon fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" points="19.523 25.523 18.324 21.999 20.776 24.8 21.5 21.148 22.223 24.8 24.675 21.999 23.476 25.523 27 24.323 24.199 26.776 27.851 27.499 24.199 28.223 27 30.675 23.476 29.475 24.675 33 22.223 30.199 21.5 33.851 20.776 30.199 18.324 33 19.523 29.475 15.999 30.675 18.8 28.223 15.148 27.499 18.8 26.776 15.999 24.323 19.523 25.523"/>
     <circle cx="21.4995" cy="27.4992" r="4.0888" fill="none" stroke="#1e50a0" stroke-miterlimit="10"/>
   </g>
   <g id="line">
-    <rect x="5" y="17" width="62" height="38" stroke-width="2" stroke="#000" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>


### PR DESCRIPTION
Fixing Taiwanese flag 🇹🇼 `1F1F9-1F1FC` as mentioned in issue hfg-gmuend#150

> Changes needed 
> — make the sun bigger
> — _(potentially)_ separating out the rays from the core; might mean making the core smaller than official to allow for the rays to split out and align with the OpenMoji style... will have to play around with that



| OpenMoji v12.3.0 | Proposed | Official |
| ------ | ------ | ------ |
| <img width="200" src="https://raw.githubusercontent.com/hfg-gmuend/openmoji/dab906e9fc301673044ff18c58f791fec3372f18/src/flags/country-flag/1F1F9-1F1FC.svg"> | <img width="200" src="https://raw.githubusercontent.com/wayne-shih/HfG-OpenMoji/ws/%F0%9F%87%B9%F0%9F%87%BC1F1F9-1F1FC/src/flags/country-flag/1F1F9-1F1FC.svg"> | <img width="160" src="https://upload.wikimedia.org/wikipedia/commons/7/72/Flag_of_the_Republic_of_China.svg"> |
