### PR TITLE
fix(🇲🇿): add yellow star, white book

### DIFF
--- a/src/flags/country-flag/1F1F2-1F1FF.svg
+++ b/src/flags/country-flag/1F1F2-1F1FF.svg
@@ -1,22 +1,22 @@
-<svg id="emoji" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
   <g id="grid">
-    <path d="M68,4V68H4V4H68m4-4H0V72H72Z" fill="#b3b3b3"/>
-    <path d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814h0V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352h0V12.8813a1.9231,1.9231,0,0,1,1.923-1.923Z" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="16" y="4" width="40" height="64" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="4" y="16" width="64" height="40" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72Z"/>
+    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814h0V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352h0V12.8813a1.9231,1.9231,0,0,1,1.923-1.923Z"/>
+    <rect x="16" y="4" rx="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="4" y="16" rx="2.2537" width="64" height="40" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
     <rect x="5" y="17" width="62" height="38" fill="#fcea2b"/>
     <rect x="5" y="17" width="62" height="13" fill="#186648"/>
     <rect x="5" y="30" width="62" height="12" stroke="#fff" stroke-miterlimit="10" stroke-width="2"/>
-    <polygon points="26 36 5 55 5 17 26 36" fill="#d22f27"/>
-    <polygon points="10.004 41.409 13.593 30.591 16.689 41.245 8.091 34.825 18.909 34.559 10.004 41.409" fill="#fcea2b" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round"/>
-    <polygon points="16.869 38.804 10.131 38.804 11.033 35.585 15.967 35.585 16.869 38.804" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round"/>
-    <line x1="8.9345" y1="40.121" x2="16.2625" y2="32.7804" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
-    <line x1="10.7376" y1="32.7804" x2="18.0655" y2="40.121" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+    <polygon fill="#d22f27" points="26 36 5 55 5 17 26 36"/>
+    <polygon fill="#fcea2b" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round" points="10.004 41.409 13.593 30.591 16.689 41.245 8.091 34.825 18.909 34.559 10.004 41.409"/>
+    <polygon fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" points="16.869 38.804 10.131 38.804 11.033 35.585 15.967 35.585 16.869 38.804"/>
+    <line x1="8.9345" x2="16.2625" y1="40.121" y2="32.7804" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+    <line x1="10.7376" x2="18.0655" y1="32.7804" y2="40.121" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
   </g>
   <g id="line">
-    <rect x="5" y="17" width="62" height="38" stroke-width="2" stroke="#000" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>

--- a/src/flags/country-flag/1F1F2-1F1FF.svg
+++ b/src/flags/country-flag/1F1F2-1F1FF.svg
@@ -1,20 +1,22 @@
-<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+<svg id="emoji" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72">
   <g id="grid">
-    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72V0Z"/>
-    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352V12.8813A1.923,1.923,0,0,1,12.923,10.9583Z"/>
-    <rect x="16" y="4" rx="2.2537" ry="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
-    <rect x="16" y="4" rx="2.2537" ry="2.2537" width="40" height="64" transform="translate(72) rotate(90)" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <path d="M68,4V68H4V4H68m4-4H0V72H72Z" fill="#b3b3b3"/>
+    <path d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814h0V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352h0V12.8813a1.9231,1.9231,0,0,1,1.923-1.923Z" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="16" y="4" width="40" height="64" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="4" y="16" width="64" height="40" rx="2.2537" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
     <rect x="5" y="17" width="62" height="38" fill="#fcea2b"/>
     <rect x="5" y="17" width="62" height="13" fill="#186648"/>
     <rect x="5" y="30" width="62" height="12" stroke="#fff" stroke-miterlimit="10" stroke-width="2"/>
-    <polygon fill="#d22f27" points="26 36 5 55 5 17 26 36"/>
-    <line x1="9.4358" x2="15.5642" y1="38.5711" y2="33.4288" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
-    <line x1="11.4359" x2="17.5642" y1="33.4288" y2="38.5711" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+    <polygon points="26 36 5 55 5 17 26 36" fill="#d22f27"/>
+    <polygon points="10.004 41.409 13.593 30.591 16.689 41.245 8.091 34.825 18.909 34.559 10.004 41.409" fill="#fcea2b" stroke="#fcea2b" stroke-linecap="round" stroke-linejoin="round"/>
+    <polygon points="16.869 38.804 10.131 38.804 11.033 35.585 15.967 35.585 16.869 38.804" fill="#fff" stroke="#fff" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="8.9345" y1="40.121" x2="16.2625" y2="32.7804" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+    <line x1="10.7376" y1="32.7804" x2="18.0655" y2="40.121" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
   </g>
   <g id="line">
-    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+    <rect x="5" y="17" width="62" height="38" stroke-width="2" stroke="#000" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
   </g>
 </svg>


### PR DESCRIPTION
Fixing Mozambique flag 🇲🇿 `1F1F2-1F1FF` as mentioned in issue hfg-gmuend#150

> Mozambique: Add a yellow star.

Also added a white isosceles trapezoid to reflect an open book on the official flag

| OpenMoji v12.3.0 | Proposed | Official |
| ------ | ------ | ------ |
| <img width="200" src="https://raw.githubusercontent.com/hfg-gmuend/openmoji/dab906e9fc301673044ff18c58f791fec3372f18/src/flags/country-flag/1F1F2-1F1FF.svg"> | <img width="200" src="https://raw.githubusercontent.com/wayne-shih/HfG-OpenMoji/ws/%F0%9F%87%B2%F0%9F%87%BF1F1F2-1F1FF/src/flags/country-flag/1F1F2-1F1FF.svg"> | <img width="160" src="https://upload.wikimedia.org/wikipedia/commons/d/d0/Flag_of_Mozambique.svg"> |
