### PR TITLE
add subdivision flag de-by, Bavaria

### DIFF
--- a/data/extras-unicode.csv
+++ b/data/extras-unicode.csv
@@ -45,3 +45,4 @@ emoji,hexcode,group,subgroups,annotation,openmoji_tags,openmoji_author,openmoji_
 ℠,2120,extras-unicode,symbol-other,service mark,"trademark, sm",Carlin MacKenzie,2020-06-06,1.1
 ℗,2117,extras-unicode,symbol-other,sound recording copyright,"trademark, music, phonogram",Carlin MacKenzie,2020-06-06,1.1
 🄯,1F12F,extras-unicode,symbol-other,copyleft symbol,"open source, free, libre, reciprocal",Carlin MacKenzie,2020-06-06,11
+🏴󠁤󠁥󠁢󠁹󠁿,1F3F4-E0064-E0065-E0062-E0079-E007F,extras-unicode,subdivision-flag,bavaria flag,"state, lozenge",Manuel Strehl,2020-07-09,?

--- a/data/openmoji.csv
+++ b/data/openmoji.csv
@@ -3510,6 +3510,7 @@ emoji,hexcode,group,subgroups,annotation,tags,openmoji_tags,openmoji_author,open
 ,E268,extras-openmoji,ui-element,add contact,,"add, contact",Kai Magnus Müller,2018-04-18,,,,,,
 ,E269,extras-openmoji,ui-element,link,,"link, chain",Kai Magnus Müller,2018-04-18,,,,,,
 🏴󠁤󠁥󠁢󠁥󠁿,1F3F4-E0064-E0065-E0062-E0065-E007F,extras-unicode,subdivision-flag,berlin flag,,"bear, city, capital",Alexander Müller,2020-04-26,,,,,?,
+🏴󠁤󠁥󠁢󠁹󠁿,1F3F4-E0064-E0065-E0062-E0079-E007F,extras-unicode,subdivision-flag,bavaria flag,,"state, lozenge",Manuel Strehl,2020-07-09,,,,,?,
 🏴󠁵󠁳󠁣󠁡󠁿,1F3F4-E0075-E0073-E0063-E0061-E007F,extras-unicode,subdivision-flag,california flag,,"bear, republic, state",Alexander Müller,2020-04-26,,,,,?,
 🏴󠁵󠁳󠁴󠁸󠁿,1F3F4-E0075-E0073-E0074-E0078-E007F,extras-unicode,subdivision-flag,texas flag,,"cowboy, lone star, republic, state",Carlin MacKenzie,2020-04-03,,,,,?,
 🄍,1F10D,extras-unicode,symbol-other,circled zero with slash,,"license, copyright, creative commons, open, libre, public domain",Carlin MacKenzie,2020-04-17,,,,,13,

--- a/data/openmoji.json
+++ b/data/openmoji.json
@@ -59687,6 +59687,23 @@
     "order": ""
   },
   {
+    "emoji": "🏴󠁤󠁥󠁢󠁹󠁿",
+    "hexcode": "1F3F4-E0064-E0065-E0062-E0079-E007F",
+    "group": "extras-unicode",
+    "subgroups": "subdivision-flag",
+    "annotation": "bavaria flag",
+    "tags": "",
+    "openmoji_tags": "state, lozenge",
+    "openmoji_author": "Manuel Strehl",
+    "openmoji_date": "2020-07-09",
+    "skintone": "",
+    "skintone_combination": "",
+    "skintone_base_emoji": "",
+    "skintone_base_hexcode": "",
+    "unicode": "?",
+    "order": ""
+  },
+  {
     "emoji": "🏴󠁵󠁳󠁣󠁡󠁿",
     "hexcode": "1F3F4-E0075-E0073-E0063-E0061-E007F",
     "group": "extras-unicode",

--- a/src/extras-unicode/subdivision-flag/1F3F4-E0064-E0065-E0062-E0079-E007F.svg
+++ b/src/extras-unicode/subdivision-flag/1F3F4-E0064-E0065-E0062-E0079-E007F.svg
@@ -1,0 +1,19 @@
+<svg id="emoji" viewBox="0 0 72 72" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g id="grid">
+    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72V0Z"/>
+    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352V12.8813A1.923,1.923,0,0,1,12.923,10.9583Z"/>
+    <rect x="16" y="4" rx="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="16" y="4" rx="2.2537" width="40" height="64" transform="translate(72) rotate(90)" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+  </g>
+  <g id="line-supplement">
+    <path transform="translate(6,18)" fill="#000" d="M 57.81375,0 L 44.5425,0 60,34.2 60,36 47.5425,36 31.27125,0 18,0 34.27125,36 21,36 9,9.45 0,7.155 0,18.9 7.72875,36 21,36 0,30.645 0,18.9 60,34.2 60,22.455 9,9.45 4.72875,0 18,0 60,10.71 60,4.8375 z"/>
+  </g>
+  <g id="color">
+    <rect x="5" y="17" width="62" height="38" fill="#fff"/>
+    <path transform="translate(6,18)" fill="#61B2E4" d="M 57.81375,0 L 44.5425,0 60,34.2 60,36 47.5425,36 31.27125,0 18,0 34.27125,36 21,36 9,9.45 0,7.155 0,18.9 7.72875,36 21,36 0,30.645 0,18.9 60,34.2 60,22.455 9,9.45 4.72875,0 18,0 60,10.71 60,4.8375 z"/>
+  </g>
+  <g id="line">
+    <path fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M67 17H5V55H67V17Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
From the commit message:

> TODO: b/w generates an empty frame. The result should be either solid black lozenges or, which would be heraldically better, vertically striped ones.
> 
> The official blue is #008DC9. The emoji uses the closest approximation from the OpenMoji color palette, #61B2E4. The tester app shows all tests green.

I’ve tried to align this submission closely to [the one adding the Berlin flag](https://github.com/hfg-gmuend/openmoji/pull/198).

The source for the official color specification is https://www.km.bayern.de/download/10702_anlage_4a_manual_cd.pdf .

Re: b/w: Is there a possibility to have a hidden element in the `line` layer, that can be unveiled by the `helpers/lib/export-svg-black.js` script? Or would it be better, if I provided a dedicated black-white emoji version? The California flag shares the same problem, i.e., its b/w representation is a simple white rectangle.