### PR TITLE
Add an EditorConfig config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,9 @@
 root = true
 
-[*.{js,json,sh,svg}]
+[*.{css,js,json,sh,svg}]
 indent_style = space
 indent_size = 2
 
-[*.{html}]
+[*.html]
 indent_style = space
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{js,json,sh,svg}]
+indent_style = space
+indent_size = 2
+
+[*.{html}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) is a standard for configuring indentation styles (amongst other things).  It is supported by many different text editors.

The config file added by this commit will tell supporting editors to use two spaces for indentation (except in HTML files, where four spaces will be used).  This matches the existing practice of the OpenMoji project.