### PR TITLE
Fix South Sudan flag star orientation.

### DIFF
--- a/src/flags/country-flag/1F1F8-1F1F8.svg
+++ b/src/flags/country-flag/1F1F8-1F1F8.svg
@@ -11,7 +11,7 @@
     <rect x="5" y="17" width="62" height="13"/>
     <rect x="5" y="30" width="62" height="12" fill="#d22f27" stroke="#fff" stroke-miterlimit="10"/>
     <polygon fill="#1e50a0" points="26 36 5 55 5 17 26 36"/>
-    <polygon fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" points="13.5 33.5 15.045 38.5 11 35.41 16 35.41 11.955 38.5 13.5 33.5"/>
+    <polygon fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" points="10.5 36 15.5 37.545 12.41 33.5 12.41 38.5 15.5 34.455 10.5 36"/>
   </g>
   <g id="line">
     <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>


### PR DESCRIPTION
Contrary to all the other flags I know, the star in the [flag of South Sudan](https://en.wikipedia.org/wiki/Flag_of_South_Sudan) points left instead of up. Unfortunately I could not find any information on why it is so.