### PR TITLE
Remove problematic id attributes from certain SVG elements.

### DIFF
--- a/src/food-drink/dishware/1F944.svg
+++ b/src/food-drink/dishware/1F944.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <path id="_xD83E__xDD44_" fill="#D0CFCE" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M43.4573,21.3227c0-5.0582-2.6112-9.1586-5.8323-9.1586s-5.8323,4.1004-5.8323,9.1586c0,4.6982,1.3551,8.5665,4.257,9.0938l0,0	l-0.8108,28.4123c0,1.1046,0.8954,2,2,2s2-0.8954,2-2l-0.0285-28.4181l0,0C42.1071,29.876,43.4573,26.0153,43.4573,21.3227z"/>
+    <path fill="#D0CFCE" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M43.4573,21.3227c0-5.0582-2.6112-9.1586-5.8323-9.1586s-5.8323,4.1004-5.8323,9.1586c0,4.6982,1.3551,8.5665,4.257,9.0938l0,0	l-0.8108,28.4123c0,1.1046,0.8954,2,2,2s2-0.8954,2-2l-0.0285-28.4181l0,0C42.1071,29.876,43.4573,26.0153,43.4573,21.3227z"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <path id="_xD83E__xDD44_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M43.4573,21.3227c0-5.0582-2.6112-9.1586-5.8323-9.1586s-5.8323,4.1004-5.8323,9.1586c0,4.6982,1.3551,8.5665,4.257,9.0938l0,0	l-0.8108,28.4123c0,1.1046,0.8954,2,2,2s2-0.8954,2-2l-0.0285-28.4181l0,0C42.1071,29.876,43.4573,26.0153,43.4573,21.3227z"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M43.4573,21.3227c0-5.0582-2.6112-9.1586-5.8323-9.1586s-5.8323,4.1004-5.8323,9.1586c0,4.6982,1.3551,8.5665,4.257,9.0938l0,0	l-0.8108,28.4123c0,1.1046,0.8954,2,2,2s2-0.8954,2-2l-0.0285-28.4181l0,0C42.1071,29.876,43.4573,26.0153,43.4573,21.3227z"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2194.svg
+++ b/src/symbols/arrow/2194.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2194__xFE0F_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="50.2632,20.2344 46.5538,24.269 55.7618,32.9375 16.2382,32.9375 25.4458,24.269 21.7368,20.2344 5,35.998 21.7368,51.7646 25.4458,47.7314 16.2449,39.0664 55.7551,39.0664 46.5538,47.7314 50.2632,51.7646 67,35.998"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="50.2632,20.2344 46.5538,24.269 55.7618,32.9375 16.2382,32.9375 25.4458,24.269 21.7368,20.2344 5,35.998 21.7368,51.7646 25.4458,47.7314 16.2449,39.0664 55.7551,39.0664 46.5538,47.7314 50.2632,51.7646 67,35.998"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2194__xFE0F_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="50.2632,20.2344 46.5538,24.269 55.7618,32.9375 16.2382,32.9375 25.4458,24.269 21.7368,20.2344 5,35.998 21.7368,51.7646 25.4458,47.7314 16.2449,39.0664 55.7551,39.0664 46.5538,47.7314 50.2632,51.7646 67,35.998"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="50.2632,20.2344 46.5538,24.269 55.7618,32.9375 16.2382,32.9375 25.4458,24.269 21.7368,20.2344 5,35.998 21.7368,51.7646 25.4458,47.7314 16.2449,39.0664 55.7551,39.0664 46.5538,47.7314 50.2632,51.7646 67,35.998"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2195.svg
+++ b/src/symbols/arrow/2195.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2195__xFE0F_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="51.7651,50.2627 47.7305,46.5533 39.062,55.7613 39.062,16.2377 47.7305,25.4453 51.7651,21.7363 36.0015,4.9995 20.2349,21.7363 24.2681,25.4453 32.9331,16.2445 32.9331,55.7546 24.2681,46.5533 20.2349,50.2627 36.0015,66.9995"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="51.7651,50.2627 47.7305,46.5533 39.062,55.7613 39.062,16.2377 47.7305,25.4453 51.7651,21.7363 36.0015,4.9995 20.2349,21.7363 24.2681,25.4453 32.9331,16.2445 32.9331,55.7546 24.2681,46.5533 20.2349,50.2627 36.0015,66.9995"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2195__xFE0F_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="51.7651,50.2627 47.7305,46.5533 39.062,55.7613 39.062,16.2377 47.7305,25.4453 51.7651,21.7363 36.0015,4.9995 20.2349,21.7363 24.2681,25.4453 32.9331,16.2445 32.9331,55.7546 24.2681,46.5533 20.2349,50.2627 36.0015,66.9995"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="51.7651,50.2627 47.7305,46.5533 39.062,55.7613 39.062,16.2377 47.7305,25.4453 51.7651,21.7363 36.0015,4.9995 20.2349,21.7363 24.2681,25.4453 32.9331,16.2445 32.9331,55.7546 24.2681,46.5533 20.2349,50.2627 36.0015,66.9995"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2196.svg
+++ b/src/symbols/arrow/2196.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2196__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="37.8362,14.0387 13.6073,13.1416 14.5044,37.3705 20.0624,37.1647 19.5378,23.0048 55.4303,58.8973 59.3629,54.9646 23.4704,19.0721 37.6303,19.5967"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="37.8362,14.0387 13.6073,13.1416 14.5044,37.3705 20.0624,37.1647 19.5378,23.0048 55.4303,58.8973 59.3629,54.9646 23.4704,19.0721 37.6303,19.5967"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2196__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="37.8362,14.0387 13.6073,13.1416 14.5044,37.3705 20.0624,37.1647 19.5378,23.0048 55.4303,58.8973 59.3629,54.9646 23.4704,19.0721 37.6303,19.5967"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="37.8362,14.0387 13.6073,13.1416 14.5044,37.3705 20.0624,37.1647 19.5378,23.0048 55.4303,58.8973 59.3629,54.9646 23.4704,19.0721 37.6303,19.5967"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2197.svg
+++ b/src/symbols/arrow/2197.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2197__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="35.134,14.0387 59.3629,13.1416 58.4658,37.3705 52.9078,37.1647 53.4324,23.0048 17.5399,58.8973 13.6073,54.9646 49.4998,19.0721 35.3399,19.5967"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="35.134,14.0387 59.3629,13.1416 58.4658,37.3705 52.9078,37.1647 53.4324,23.0048 17.5399,58.8973 13.6073,54.9646 49.4998,19.0721 35.3399,19.5967"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2197__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="35.134,14.0387 59.3629,13.1416 58.4658,37.3705 52.9078,37.1647 53.4324,23.0048 17.5399,58.8973 13.6073,54.9646 49.4998,19.0721 35.3399,19.5967"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="35.134,14.0387 59.3629,13.1416 58.4658,37.3705 52.9078,37.1647 53.4324,23.0048 17.5399,58.8973 13.6073,54.9646 49.4998,19.0721 35.3399,19.5967"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2198.svg
+++ b/src/symbols/arrow/2198.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2198__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="57.4658,34.702 58.3629,58.9309 34.134,58.0338 34.3399,52.4758 48.4998,53.0004 12.6073,17.1079 16.5399,13.1753 52.4325,49.0678 51.9078,34.9079"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="57.4658,34.702 58.3629,58.9309 34.134,58.0338 34.3399,52.4758 48.4998,53.0004 12.6073,17.1079 16.5399,13.1753 52.4325,49.0678 51.9078,34.9079"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2198__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="57.4658,34.702 58.3629,58.9309 34.134,58.0338 34.3399,52.4758 48.4998,53.0004 12.6073,17.1079 16.5399,13.1753 52.4325,49.0678 51.9078,34.9079"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="57.4658,34.702 58.3629,58.9309 34.134,58.0338 34.3399,52.4758 48.4998,53.0004 12.6073,17.1079 16.5399,13.1753 52.4325,49.0678 51.9078,34.9079"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2199.svg
+++ b/src/symbols/arrow/2199.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2199__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="14.5044,34.702 13.6073,58.9309 37.8362,58.0338 37.6303,52.4758 23.4704,53.0004 59.3629,17.1079 55.4303,13.1753 19.5378,49.0678 20.0624,34.9079"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="14.5044,34.702 13.6073,58.9309 37.8362,58.0338 37.6303,52.4758 23.4704,53.0004 59.3629,17.1079 55.4303,13.1753 19.5378,49.0678 20.0624,34.9079"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2199__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="14.5044,34.702 13.6073,58.9309 37.8362,58.0338 37.6303,52.4758 23.4704,53.0004 59.3629,17.1079 55.4303,13.1753 19.5378,49.0678 20.0624,34.9079"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="14.5044,34.702 13.6073,58.9309 37.8362,58.0338 37.6303,52.4758 23.4704,53.0004 59.3629,17.1079 55.4303,13.1753 19.5378,49.0678 20.0624,34.9079"/>
   </g>
 </svg>

--- a/src/symbols/arrow/27A1.svg
+++ b/src/symbols/arrow/27A1.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x27A1__xFE0F_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="49.2124,51.5343 67,35.0363 49.2124,18.5382 45.4234,22.6138 55.8191,32.2554 5,32.2554 5,37.8171 55.8191,37.8171 45.4234,47.4587"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="49.2124,51.5343 67,35.0363 49.2124,18.5382 45.4234,22.6138 55.8191,32.2554 5,32.2554 5,37.8171 55.8191,37.8171 45.4234,47.4587"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x27A1__xFE0F_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="49.2124,51.5343 67,35.0363 49.2124,18.5382 45.4234,22.6138 55.8191,32.2554 5,32.2554 5,37.8171 55.8191,37.8171 45.4234,47.4587"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="49.2124,51.5343 67,35.0363 49.2124,18.5382 45.4234,22.6138 55.8191,32.2554 5,32.2554 5,37.8171 55.8191,37.8171 45.4234,47.4587"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2934.svg
+++ b/src/symbols/arrow/2934.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <path id="_x2934__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,12L26.1294,26.8587l3.7285,3.413l7.5107-7.9438v16.4924c0,10.5232-5.7598,15.6386-17.6094,15.6386h-1V60h1	c14.9902,0,23.2461-7.522,23.2461-21.1797V22.3331l7.5078,7.9386l3.7275-3.413L40.1841,12z"/>
+    <path fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,12L26.1294,26.8587l3.7285,3.413l7.5107-7.9438v16.4924c0,10.5232-5.7598,15.6386-17.6094,15.6386h-1V60h1	c14.9902,0,23.2461-7.522,23.2461-21.1797V22.3331l7.5078,7.9386l3.7275-3.413L40.1841,12z"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <path id="_x2934__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,12L26.1294,26.8587l3.7285,3.413l7.5107-7.9438v16.4924c0,10.5232-5.7598,15.6386-17.6094,15.6386h-1V60h1	c14.9902,0,23.2461-7.522,23.2461-21.1797V22.3331l7.5078,7.9386l3.7275-3.413L40.1841,12z"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,12L26.1294,26.8587l3.7285,3.413l7.5107-7.9438v16.4924c0,10.5232-5.7598,15.6386-17.6094,15.6386h-1V60h1	c14.9902,0,23.2461-7.522,23.2461-21.1797V22.3331l7.5078,7.9386l3.7275-3.413L40.1841,12z"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2935.svg
+++ b/src/symbols/arrow/2935.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <path id="_x2935__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,60L26.1294,45.1413l3.7285-3.413l7.5107,7.9438V33.1797c0-10.5232-5.7598-15.6386-17.6094-15.6386h-1V12h1	c14.9902,0,23.2461,7.522,23.2461,21.1797v16.4872l7.5078-7.9386l3.7275,3.413L40.1841,60z"/>
+    <path fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,60L26.1294,45.1413l3.7285-3.413l7.5107,7.9438V33.1797c0-10.5232-5.7598-15.6386-17.6094-15.6386h-1V12h1	c14.9902,0,23.2461,7.522,23.2461,21.1797v16.4872l7.5078-7.9386l3.7275,3.413L40.1841,60z"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <path id="_x2935__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,60L26.1294,45.1413l3.7285-3.413l7.5107,7.9438V33.1797c0-10.5232-5.7598-15.6386-17.6094-15.6386h-1V12h1	c14.9902,0,23.2461,7.522,23.2461,21.1797v16.4872l7.5078-7.9386l3.7275,3.413L40.1841,60z"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M40.1841,60L26.1294,45.1413l3.7285-3.413l7.5107,7.9438V33.1797c0-10.5232-5.7598-15.6386-17.6094-15.6386h-1V12h1	c14.9902,0,23.2461,7.522,23.2461,21.1797v16.4872l7.5078-7.9386l3.7275,3.413L40.1841,60z"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2B05.svg
+++ b/src/symbols/arrow/2B05.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2B05__xFE0F_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="22.7876,51.5343 5,35.0363 22.7876,18.5382 26.5766,22.6138 16.1809,32.2554 67,32.2554 67,37.8171 16.1809,37.8171 26.5766,47.4587"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="22.7876,51.5343 5,35.0363 22.7876,18.5382 26.5766,22.6138 16.1809,32.2554 67,32.2554 67,37.8171 16.1809,37.8171 26.5766,47.4587"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2B05__xFE0F_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="22.7876,51.5343 5,35.0363 22.7876,18.5382 26.5766,22.6138 16.1809,32.2554 67,32.2554 67,37.8171 16.1809,37.8171 26.5766,47.4587"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="22.7876,51.5343 5,35.0363 22.7876,18.5382 26.5766,22.6138 16.1809,32.2554 67,32.2554 67,37.8171 16.1809,37.8171 26.5766,47.4587"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2B06.svg
+++ b/src/symbols/arrow/2B06.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2B06__xFE0F__1_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="19.5019,22.8239 36,5.0363 52.4981,22.8239 48.4224,26.6128 38.7808,16.2171 38.7808,67.0363 33.2192,67.0363 33.2192,16.2171 23.5776,26.6128"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="19.5019,22.8239 36,5.0363 52.4981,22.8239 48.4224,26.6128 38.7808,16.2171 38.7808,67.0363 33.2192,67.0363 33.2192,16.2171 23.5776,26.6128"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2B06__xFE0F__1_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="19.5019,22.8239 36,5.0363 52.4981,22.8239 48.4224,26.6128 38.7808,16.2171 38.7808,67.0363 33.2192,67.0363 33.2192,16.2171 23.5776,26.6128"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="19.5019,22.8239 36,5.0363 52.4981,22.8239 48.4224,26.6128 38.7808,16.2171 38.7808,67.0363 33.2192,67.0363 33.2192,16.2171 23.5776,26.6128"/>
   </g>
 </svg>

--- a/src/symbols/arrow/2B07.svg
+++ b/src/symbols/arrow/2B07.svg
@@ -7,12 +7,12 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <polygon id="_x2B07__xFE0F_" fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="52.4981,49.2486 36,67.0363 19.5019,49.2486 23.5776,45.4597 33.2192,55.8554 33.2192,5.0363 38.7808,5.0363 38.7808,55.8554 48.4224,45.4597"/>
+    <polygon fill="#3F3F3F" stroke="none" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="52.4981,49.2486 36,67.0363 19.5019,49.2486 23.5776,45.4597 33.2192,55.8554 33.2192,5.0363 38.7808,5.0363 38.7808,55.8554 48.4224,45.4597"/>
   </g>
   <g id="hair"/>
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <polygon id="_x2B07__xFE0F_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="52.4981,49.2486 36,67.0363 19.5019,49.2486 23.5776,45.4597 33.2192,55.8554 33.2192,5.0363 38.7808,5.0363 38.7808,55.8554 48.4224,45.4597"/>
+    <polygon fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" points="52.4981,49.2486 36,67.0363 19.5019,49.2486 23.5776,45.4597 33.2192,55.8554 33.2192,5.0363 38.7808,5.0363 38.7808,55.8554 48.4224,45.4597"/>
   </g>
 </svg>

--- a/src/symbols/av-symbol/1F53C.svg
+++ b/src/symbols/av-symbol/1F53C.svg
@@ -11,6 +11,6 @@
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <path id="_xD83D__xDD3C_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M14.8653,55L25,36.1176l9.9304-18.5018c0.4407-0.8211,1.6984-0.8211,2.1391,0L47,36.1176L57.1347,55"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M14.8653,55L25,36.1176l9.9304-18.5018c0.4407-0.8211,1.6984-0.8211,2.1391,0L47,36.1176L57.1347,55"/>
   </g>
 </svg>

--- a/src/symbols/av-symbol/1F53D.svg
+++ b/src/symbols/av-symbol/1F53D.svg
@@ -11,6 +11,6 @@
   <g id="skin"/>
   <g id="skin-shadow"/>
   <g id="line">
-    <path id="_xD83D__xDD3D_" fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M57.1347,17L47,35.8824l-9.9304,18.5018c-0.4407,0.8211-1.6984,0.8211-2.1391,0L25,35.8824L14.8653,17"/>
+    <path fill="none" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" d="M57.1347,17L47,35.8824l-9.9304,18.5018c-0.4407,0.8211-1.6984,0.8211-2.1391,0L25,35.8824L14.8653,17"/>
   </g>
 </svg>


### PR DESCRIPTION
Some of the SVG files have multiple elements with the same id.
This violates the specifications for the SVG format, and caused problems when I was trying to parse the files with another program.

Comparing these files to the other SVG sources for OpenMoji, I found that these id attributes are nonstandard.
Most of the SVG files have descriptive ids for each group ("line", "color", "skin", etc.), but not for the elements within those groups.
As such, the easiest fix was to simply remove those problematic id attributes.

Additionally, each of these duplicate id attributes have a form similar to `id="_x2935__xFE0F__1_"`.
While scanning the files,  I also found two av-symbol SVG files which had this form of id, but without the duplication.
Although these two files don't violate the specifications for SVG, I have also removed the id attributes therein for the sake of consistency with the other files in the repo.

This pull request fixes issue #372 