### PR TITLE
Flipping the symbol for ionising radiation to correct orientation

### DIFF
--- a/color/svg/2622.svg
+++ b/color/svg/2622.svg
@@ -4,9 +4,9 @@
   </g>
   <g id="line">
     <ellipse cx="35.96" cy="35.89" rx="3.281" ry="3.281" stroke="#000" stroke-miterlimit="10" stroke-width="1.25"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="1.254" d="m23.09 43.42a14.76 14.76 0 0 0 3.496 4.097l5.791-6.957a5.733 5.733 0 0 1-2.167-3.753l-8.921 1.537a14.76 14.76 0 0 0 1.8 5.076z"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="1.254" d="m48.91 43.42a14.76 14.76 0 0 0 1.8-5.076l-8.921-1.537a5.733 5.733 0 0 1-2.167 3.753l5.791 6.957a14.76 14.76 0 0 0 3.496-4.097z"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="1.254" d="m36 21.13a14.76 14.76 0 0 0-5.296 0.9794l3.129 8.494a5.733 5.733 0 0 1 4.333 0l3.129-8.494a14.76 14.76 0 0 0-5.296-0.9794z"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="1.254" d="m 23.09 28.58 a 14.76 14.76 0 0 1 3.496 -4.097 l 5.791 6.957 a 5.733 5.733 0 0 0 -2.167 3.753 l -8.921 -1.537 a 14.76 14.76 0 0 1 1.8 -5.076 z"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="1.254" d="m 48.91 28.58 a 14.76 14.76 0 0 1 1.8 5.076 l -8.921 1.537 a 5.733 5.733 0 0 0 -2.167 -3.753 l 5.791 -6.957 a 14.76 14.76 0 0 1 3.496 4.097 z"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="1.254" d="m 36 50.87 a 14.76 14.76 0 0 1 -5.296 -0.9794 l 3.129 -8.494 a 5.733 5.733 0 0 0 4.333 0 l 3.129 8.494 a 14.76 14.76 0 0 1 -5.296 0.9794 z"/>
     <circle cx="36" cy="36" r="23" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
   </g>
 </svg>


### PR DESCRIPTION
I noticed that the radiation symbol in openmoji is upside down, especially when [compared to other emoji sets](https://emojipedia.org/radioactive/), and the ANSI spec of it.

This should flip it over