### PR TITLE
FAQ: Better javascript implementation to also support emojis like 👩‍⚕️

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -108,16 +108,18 @@ This script can be added to any website:
 <html>
 <script>
     function get_emoji(emoji) {
-        let emoji_code = emoji.codePointAt(0).toString(16).toUpperCase();
+        let emoji_code = [...emoji].map(e => e.codePointAt(0).toString(16)).join(`-`).toUpperCase();
         new_url = `https://openmoji.org/data/color/svg/${emoji_code}.svg`
         document.write(`<img src=${new_url} style="height: 80px;">`);
     }
     get_emoji("🦴")
     get_emoji("🎭")
+    get_emoji("👩‍⚕️")
 </script>
+</html>
 ```
 
-</html>
+
 
 </details>
 
@@ -144,9 +146,9 @@ def get_emoji(emoji):
 
 get_emoji("🦴")
 get_emoji("🎭")
+get_emoji("👩‍⚕️")
 ```
 
-</html>
 
 </details>
 


### PR DESCRIPTION
I just found a problem in the JavaScript implementation:
Emojis like 👩‍⚕️ have two parts: 👩 +⚕️.
But the current JavaScript implementation takes only the first codePoint into account.
The new implementation will take care of both cases: Single character emojies and double character emojis.
```
code = [...emoji].map(e => e.codePointAt(0).toString(16)).join(`-`)
```
The python implementation works fine though.
Follow up to #397, @b-g .