### PR TITLE
FAQ: Better handeling of unicode value U+FE0F  with Python+Javascript.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -108,14 +108,18 @@ This script can be added to any website:
 <html>
 <script>
     function get_emoji(emoji) {
-        let emoji_code = [...emoji].map(e => e.codePointAt(0).toString(16)).join(`-`).toUpperCase().replace("-FE0F", "");
+        let emoji_code = [...emoji].map(e => e.codePointAt(0).toString(16).padStart(4, '0')).join(`-`).toUpperCase()
+        if (emoji.length === 3) emoji_code = emoji_code.replace("-FE0F", "");
         new_url = `https://openmoji.org/data/color/svg/${emoji_code}.svg`
         document.write(`<img src=${new_url} style="height: 80px;">`);
+        document.write(emoji_code)
     }
     get_emoji("🦴")
     get_emoji("🐿️")
+    get_emoji("5️⃣") // problem here 0035-FE0F-20E3 -> the FE0F is removed. javascript "replace" function has to be something like removesuffix
     get_emoji("👩‍⚕️")
 </script>
+
 </html>
 ```
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -109,15 +109,15 @@ This script can be added to any website:
 <script>
     function get_emoji(emoji) {
         let emoji_code = [...emoji].map(e => e.codePointAt(0).toString(16).padStart(4, '0')).join(`-`).toUpperCase()
-        if (emoji.length === 3) emoji_code = emoji_code.replace("-FE0F", "");
+        if (emoji_code.length === 10) emoji_code = emoji_code.replace("-FE0F", "");
         new_url = `https://openmoji.org/data/color/svg/${emoji_code}.svg`
         document.write(`<img src=${new_url} style="height: 80px;">`);
-        document.write(emoji_code)
     }
     get_emoji("🦴")
     get_emoji("🐿️")
-    get_emoji("5️⃣") // problem here 0035-FE0F-20E3 -> the FE0F is removed. javascript "replace" function has to be something like removesuffix
+    get_emoji("5️⃣")
     get_emoji("👩‍⚕️")
+    get_emoji("🏳️")
 </script>
 
 </html>
@@ -143,19 +143,18 @@ import requests
 
 def get_emoji(emoji):
     emoji_code = "-".join(f"{ord(c):04x}" for c in emoji).upper()
-    if len(emoji) == 2:
+    if len(emoji_code) == 10:
         emoji_code = emoji_code.removesuffix("-FE0F")
     url = f"https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/{emoji_code}.png"
     im = Image.open(requests.get(url, stream=True).raw)
     # image = np.array(im.convert("RGBA")) 
     return im
 
-
 get_emoji("🦴")
 get_emoji("🐿️")
 get_emoji("5️⃣")
 get_emoji("👩‍⚕️")
-
+get_emoji("🏳️")
 ```
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -138,15 +138,20 @@ from PIL import Image
 import requests
 
 def get_emoji(emoji):
-    emoji_code = "-".join(f"{ord(c):x}" for c in emoji).upper().replace("-FE0F", "")
+    emoji_code = "-".join(f"{ord(c):04x}" for c in emoji).upper()
+    if len(emoji) == 2:
+        emoji_code = emoji_code.removesuffix("-FE0F")
     url = f"https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/{emoji_code}.png"
     im = Image.open(requests.get(url, stream=True).raw)
-   # image = np.array(im.convert("RGBA")) 
+    # image = np.array(im.convert("RGBA")) 
     return im
+
 
 get_emoji("🦴")
 get_emoji("🐿️")
+get_emoji("5️⃣")
 get_emoji("👩‍⚕️")
+
 ```
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -108,12 +108,12 @@ This script can be added to any website:
 <html>
 <script>
     function get_emoji(emoji) {
-        let emoji_code = [...emoji].map(e => e.codePointAt(0).toString(16)).join(`-`).toUpperCase();
+        let emoji_code = [...emoji].map(e => e.codePointAt(0).toString(16)).join(`-`).toUpperCase().replace("-FE0F", "");
         new_url = `https://openmoji.org/data/color/svg/${emoji_code}.svg`
         document.write(`<img src=${new_url} style="height: 80px;">`);
     }
     get_emoji("🦴")
-    get_emoji("🎭")
+    get_emoji("🐿️")
     get_emoji("👩‍⚕️")
 </script>
 </html>
@@ -138,14 +138,14 @@ from PIL import Image
 import requests
 
 def get_emoji(emoji):
-    emoji_code = "-".join(f"{ord(c):x}" for c in emoji).upper()
+    emoji_code = "-".join(f"{ord(c):x}" for c in emoji).upper().replace("-FE0F", "")
     url = f"https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/{emoji_code}.png"
     im = Image.open(requests.get(url, stream=True).raw)
    # image = np.array(im.convert("RGBA")) 
     return im
 
 get_emoji("🦴")
-get_emoji("🎭")
+get_emoji("🐿️")
 get_emoji("👩‍⚕️")
 ```
 


### PR DESCRIPTION
Don't merge yet, it's only a draft pull request.
Attempt to solve  #404.
@Joshix-1 can you have a look at this?
It's not yet a working solution, because sometimes this character is needed:

🦴 -> "1F9B4", can be found in https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F9B4.png
🐿️ -> "1F43F-FE0F" , can be found in https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F43F.png
👩‍⚕️ -> "1F469-200D-2695-FE0F" can be found in https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/72x72/1F469-200D-2695-FE0F.png

Currently, the last example would break, because the FE0F should not be removed.
I think a distinction of cases is needed here. Am I right in the assumption, that all emojis that have more than two of these character sequences separated by a "-"  should not have removed the last `FE0F` ?