### PR TITLE
Split `annotation` and `openmoji_tags` for E24D in extras-openmoji.csv

### DIFF
--- a/data/extras-openmoji.csv
+++ b/data/extras-openmoji.csv
@@ -116,7 +116,7 @@ emoji,hexcode,group,subgroups,annotation,openmoji_tags,openmoji_author,openmoji_
 ,E204,extras-openmoji,travel-places,elevator,elevator,Kai Magnus Müller,2018-04-18
 ,E200,extras-openmoji,travel-places,cafeteria,,Baris Camli,2018-04-18
 ,E206,extras-openmoji,travel-places,parking garage,"parking lot, car, automobile, vehicle, sign, traffic sign, p",Kai Wanschura,2018-04-18
-,E24D,extras-openmoji,ui-element,"return, back button",,Jose Avila,2018-04-18
+,E24D,extras-openmoji,ui-element,return,back button,Jose Avila,2018-04-18
 ,E24E,extras-openmoji,ui-element,close,,Jose Avila,2018-04-18
 ,E25B,extras-openmoji,ui-element,duplicate,"make copy, second, file, create, page, document",Kai Wanschura,2018-04-18
 ,E24F,extras-openmoji,ui-element,forward,,Jose Avila,2018-04-18


### PR DESCRIPTION
The `annotation` field was set to "return, back button", and the `openmoji_tags` was empty.

Typically the `annotation` field is not a comma-separated list, but a simple string, so it was changed to be simply "return" (which aligns with the other ui-element entries below, such as "close", "duplicate", "forward", etc.) and "back button" was moved to the `openmoji_tags` field.
