### PR TITLE
Font format recommendations

### DIFF
--- a/font/README.md
+++ b/font/README.md
@@ -35,7 +35,7 @@ The color font comes in a variety of formats:
 | [`OpenMoji-color-sbix`](OpenMoji-color-sbix) | `SBIX` | Format primarily used by Apple | Bitmap        | Safari, Chrome-based browsers, some desktop applications, MacOS, iOS |
 | [`OpenMoji-color-untouchedsvgz`](OpenMoji-color-untouchedsvgz) | `SVG` in OpenType | `SVG`-based format without compression tricks | Vector        | Firefox and Safari, some desktop applications |
 | [`OpenMoji-color-colr0_svg`](OpenMoji-color-colr0_svg) | `SVG` in OpenType, `COLRv0` | Both `SVG` and `COLRv0` in one font | Vector        | All modern webbrowsers, some desktop applications |
-| [`OpenMoji-color-colr1_svg`](OpenMoji-color-colr1_svg) | `SVG` in OpenType, `COLRv0` | Both `SVG` and `COLRv1` in one font | Vector        | Almost all modern webbrowsers, some desktop applications |
+| [`OpenMoji-color-colr1_svg`](OpenMoji-color-colr1_svg) | `SVG` in OpenType, `COLRv1` | Both `SVG` and `COLRv1` in one font | Vector        | Almost all modern webbrowsers, some desktop applications |
 
 We generally recommend:
 - `COLRv0` with `woff2` for websites

--- a/font/README.md
+++ b/font/README.md
@@ -39,7 +39,6 @@ The color font comes in a variety of formats:
 
 We generally recommend:
 - `COLRv0` with `woff2` for websites
-- `COLRv1` with `woff2` for websites if lack of support for Safari is okay
 - `SVG`+`COLRv0` with `ttf` for desktop applications, though you may want to try bitmap-based formats if this does not work.
 
 ## Further reading

--- a/font/README.md
+++ b/font/README.md
@@ -28,13 +28,13 @@ The color font comes in a variety of formats:
 
 | Directory                                    | Format | Description                             | Bitmap/Vector | Use-case                                  |
 | -------------------------------------------- | ------ | --------------------------------------- | ------------- | ----------------------------------------- |
-| [`OpenMoji-color-cbdt`](OpenMoji-color-cbdt) | `CBDT` | Early format that is largely deprecated | Bitmap        | Android applications, Old Chrome browsers |
-| [`OpenMoji-color-glyf_colr_0`](OpenMoji-color-glyf_colr_0) | `COLRv0` in OpenType | Standardised format that is superceded by `COLRv1`, limited features | Vector        | Almost all modern webbrowsers, very little support on desktop applications |
-| [`OpenMoji-color-glyf_colr_1`](OpenMoji-color-glyf_colr_1) | `COLRv1` in OpenType | Emerging standard with many features | Vector        | Most modern browsers (not Safari), very little support on desktop applications |
+| [`OpenMoji-color-cbdt`](OpenMoji-color-cbdt) | `CBDT` | Early format that is largely deprecated | Bitmap        | Android applications, Old Chrome browsers, some desktop applications |
+| [`OpenMoji-color-glyf_colr_0`](OpenMoji-color-glyf_colr_0) | `COLRv0` in OpenType | Standardised format that is superceded by `COLRv1`, limited features | Vector        | Almost all modern webbrowsers, many desktop applications |
+| [`OpenMoji-color-glyf_colr_1`](OpenMoji-color-glyf_colr_1) | `COLRv1` in OpenType | Emerging standard with many features | Vector        | Most modern browsers (not Safari), very little support on desktop applications yet |
 | [`OpenMoji-color-picosvgz`](OpenMoji-color-picosvgz) | `SVG` in OpenType | SVG-based format with compression tricks applied using `picosvg` | Vector        | Firefox and Safari, some desktop applications |
 | [`OpenMoji-color-sbix`](OpenMoji-color-sbix) | `SBIX` | Format primarily used by Apple | Bitmap        | Safari, Chrome-based browsers, some desktop applications, MacOS, iOS |
 | [`OpenMoji-color-untouchedsvgz`](OpenMoji-color-untouchedsvgz) | `SVG` in OpenType | `SVG`-based format without compression tricks | Vector        | Firefox and Safari, some desktop applications |
-| [`OpenMoji-color-colr0_svg`](OpenMoji-color-colr0_svg) | `SVG` in OpenType, `COLRv0` | Both `SVG` and `COLRv0` in one font | Vector        | All modern webbrowsers, some desktop applications |
+| [`OpenMoji-color-colr0_svg`](OpenMoji-color-colr0_svg) | `SVG` in OpenType, `COLRv0` | Both `SVG` and `COLRv0` in one font | Vector        | All modern webbrowsers, many desktop applications |
 | [`OpenMoji-color-colr1_svg`](OpenMoji-color-colr1_svg) | `SVG` in OpenType, `COLRv1` | Both `SVG` and `COLRv1` in one font | Vector        | Almost all modern webbrowsers, some desktop applications |
 
 We generally recommend:


### PR DESCRIPTION
There's two parts to this:

##  Don’t recommend COLRv1 for the web

As I understand it, COLRv1 offers two advantages over COLRv0:
- Gradients (which are something that Openmoji doesn’t use).
- More reuse of elements, leading to potentially smaller file sizes.

The COLRv1 TTF file is indeed smaller.  However, for some reason the WOFF2 file is not:

| Size    | Filename                         |
| ------- | -------------------------------- |
| 2436372 | OpenMoji-color-glyf_colr_0.ttf   |
|  905144 | OpenMoji-color-glyf_colr_0.woff2 |
| 2220984 | OpenMoji-color-glyf_colr_1.ttf   |
|  972648 | OpenMoji-color-glyf_colr_1.woff2 |

Hence, I don’t think there’s any reason to recommend COLRv1 WOFF2 at the current time.

## Be more generous about support for COLRv0 on desktop

COLRv0 is the built-in format for colour fonts in Windows 10, so I don’t think it’s fair to say that it has very little support.  These days, it’s also supported by many Linux applications too.