### PR TITLE
Update README.md: Removed link for Sticker Packs as it leads to a 404.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ You can download, use and "consume" OpenMoji in various ways:
 - [OpenMoji Spritemap Generator](https://github.com/axelpale/openmoji-spritemap-generator): OpenMoji combined to handy sprite images
 - [OpenMoji in Fedora](https://apps.fedoraproject.org/packages/hfg-gmuend-openmoji-fonts): For Fedora 33 and newer, `sudo yum install hfg-gmuend-openmoji-fonts-all`
 - [OpenMoji in JavaFX](https://github.com/pavlobu/emoji-text-flow-javafx): A cross-platform JavaFX library allowing you to replace all standard emoji in extended TextFlow (EmojiTextFlow) with OpenMoji.
-- [OpenMoji Awesome CSS Classes](https://github.com/gromain/openmoji-awesome): "Font Awesome" flavored CSS classes eg.  `<i class="oma oma-face-with-monocle"></i>` ready to use for websites.  
-- [OpenMoji Sticker Sets](https://github.com/MEibenst/openmoji-sticker-sets): Stickers for Telegram and WhatsApp.
-- [OpenMoji Flutter](https://pub.dev/packages/flutter_openmoji): OpenMoji usable as Icon for the FLutter framework.
+- [OpenMoji Awesome CSS Classes](https://github.com/gromain/openmoji-awesome): "Font Awesome" flavored CSS classes eg. `<i class="oma oma-face-with-monocle"></i>` ready to use for websites.  
+- [OpenMoji Flutter](https://pub.dev/packages/flutter_openmoji): OpenMoji usable as Icon for the Flutter framework.
 
 
 ## Attribution Requirements


### PR DESCRIPTION
Link to Sticker packs for Telegram does not exist anymore. The user neither. Googling for that sticker pack gave no results. So I've removed the link.

PS: I hope it's okay to have no issue created first as this seems pretty easy..