### PR TITLE
Provide a way to specify the version of TTFs

### DIFF
--- a/font/README.md
+++ b/font/README.md
@@ -69,7 +69,7 @@ You need to have the following installed:
 2. Open a terminal and go to the OpenMoji folder
    - `cd path/to/openmoji`
 3. Run the font builder
-   - `./helpers/generate-fonts.sh`
+   - `./helpers/generate-fonts.sh [version]`
    - Wait for build to finish. This can take a few hours for the initial run. Be patient!
 4. Done ✅
 

--- a/helpers/generate-fonts.sh
+++ b/helpers/generate-fonts.sh
@@ -11,7 +11,7 @@ set -ueo pipefail
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. || exit 1
 
 build_dir="/mnt/build"
-version=$(git describe --tags)
+version=${1:-$(git describe --tags)}
 
 # If we're connected to a terminal, don't flood it with ninja output,
 # and enable ^C.


### PR DESCRIPTION
This should be done when building TTFs for release, so that the new fonts can be committed before the Git tag is created.

Provides a way to prevent recurrences of #485.