### PR TITLE
Add flag of Ontario

### DIFF
--- a/data/extras-unicode.csv
+++ b/data/extras-unicode.csv
@@ -28,6 +28,7 @@ emoji,hexcode,group,subgroups,annotation,openmoji_tags,openmoji_author,openmoji_
 ⮻,2BBB,extras-unicode,symbol-other,overlapping white and black squares,,loominade,2020-04-22,1.1
 ⮼,2BBC,extras-unicode,symbol-other,overlapping black squares,,loominade,2020-04-22,1.1
 ⯄,2BC4,extras-unicode,symbol-other,black octagon,"equilateral polygon",loominade,2020-04-17,5
+🏴󠁣󠁡󠁯󠁮󠁿,1F3F4-E0063-E0061-E006F-E006E-E007F,extras-unicode,subdivision-flag,ontario flag,"ontario, canada, province, red ensign",JJ Marr,2026-03-16,?
 🏴󠁣󠁡󠁱󠁣󠁿,1F3F4-E0063-E0061-E0071-E0063-E007F,extras-unicode,subdivision-flag,quebec flag,"fleur-de-lis, quebec, canada, province",Denis Blanchette,2021-02-10,?
 🏴󠁵󠁳󠁣󠁡󠁿,1F3F4-E0075-E0073-E0063-E0061-E007F,extras-unicode,subdivision-flag,california flag,"bear, republic, state",Alexander Müller,2020-04-26,?
 🏴󠁤󠁥󠁢󠁥󠁿,1F3F4-E0064-E0065-E0062-E0065-E007F,extras-unicode,subdivision-flag,berlin flag,"bear, city, capital",Alexander Müller,2020-04-26,?

--- a/data/openmoji.json
+++ b/data/openmoji.json
@@ -74936,6 +74936,23 @@
     "order": ""
   },
   {
+    "emoji": "🏴󠁣󠁡󠁯󠁮󠁿",
+    "hexcode": "1F3F4-E0063-E0061-E006F-E006E-E007F",
+    "group": "extras-unicode",
+    "subgroups": "subdivision-flag",
+    "annotation": "ontario flag",
+    "tags": "",
+    "openmoji_tags": "ontario, canada, province, red ensign",
+    "openmoji_author": "JJ Marr",
+    "openmoji_date": "2026-03-16",
+    "skintone": "",
+    "skintone_combination": "",
+    "skintone_base_emoji": "",
+    "skintone_base_hexcode": "",
+    "unicode": "?",
+    "order": ""
+  },
+  {
     "emoji": "-",
     "hexcode": "002D",
     "group": "extras-unicode",

--- a/src/extras-unicode/subdivision-flag/1F3F4-E0063-E0061-E006F-E006E-E007F.svg
+++ b/src/extras-unicode/subdivision-flag/1F3F4-E0063-E0061-E006F-E006E-E007F.svg
@@ -1,0 +1,66 @@
+<svg id="emoji" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+  <g id="grid">
+    <path fill="#b3b3b3" d="M68,4V68H4V4H68m4-4H0V72H72V0Z"/>
+    <path fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1" d="M12.923,10.9583H59.0769A1.9231,1.9231,0,0,1,61,12.8814V59.0352a1.9231,1.9231,0,0,1-1.9231,1.9231H12.9231A1.9231,1.9231,0,0,1,11,59.0352V12.8813A1.923,1.923,0,0,1,12.923,10.9583Z"/>
+    <rect x="16" y="4" rx="2.2537" ry="2.2537" width="40" height="64" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <rect x="16" y="4" rx="2.2537" ry="2.2537" width="40" height="64" transform="translate(72) rotate(90)" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+    <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
+  </g>
+  <g id="color">
+    <defs>
+      <clipPath id="ontario-shield">
+        <path d="M44,27 H63 V46 Q53.5,53 44,46 Z"/>
+      </clipPath>
+    </defs>
+    <!-- Red Ensign background -->
+    <rect x="5" y="17" width="62" height="38" fill="#d22f27"/>
+    <!-- Union Jack canton (upper-left, 31x19) -->
+    <rect x="5" y="17" width="31" height="19" fill="#1e50a0"/>
+    <polygon fill="#fff" points="9.887 18 6 18 6 20.332 32.113 36 36 36 36 33.668 9.887 18"/>
+    <polygon fill="#fff" points="36 20.332 36 18 32.113 18 6 33.668 6 36 9.887 36 36 20.332"/>
+    <rect x="6" y="24" width="30" height="6" fill="#fff"/>
+    <rect x="18" y="18" width="6" height="18" fill="#fff"/>
+    <rect x="20" y="18" width="2" height="18" fill="#d22f27"/>
+    <rect x="6" y="26" width="30" height="2" fill="#d22f27"/>
+    <polygon fill="#d22f27" points="36 33.668 29.887 30 26 30 36 36 36 33.668"/>
+    <polygon fill="#d22f27" points="36 18 32.113 18 24 22.868 24 24 26 24 36 18"/>
+    <polygon fill="#d22f27" points="6 20.332 12.113 24 16 24 6 18 6 20.332"/>
+    <polygon fill="#d22f27" points="6 36 9.887 36 18 31.132 18 30 16 30 6 36"/>
+    <!-- Ontario Shield of Arms (x:44-63, y:27-51, matches Bermuda crest size) -->
+    <g clip-path="url(#ontario-shield)">
+      <!-- Upper quarter: St George's Cross (7px, ~1/4 of shield height) -->
+      <rect x="44" y="27" width="19" height="7" fill="#fff"/>
+      <polygon fill="#d22f27" points="63,29.5 55,29.5 55,27 52,27 52,29.5 44,29.5 44,31.5 52,31.5 52,34 55,34 55,31.5 63,31.5"/>
+      <!-- Lower three-quarters: Green field -->
+      <rect x="44" y="34" width="19" height="20" fill="#5c9e31"/>
+      <!-- Dividing line between cross and green field (drawn on top) -->
+      <line x1="44" y1="34" x2="63" y2="34" stroke="#000" stroke-width="1"/>
+      <!-- Main stem -->
+      <line x1="53.5" y1="50" x2="53.5" y2="46" stroke="#f1b31c" stroke-linecap="round" stroke-width="1.5"/>
+      <!-- Three branches: sides at ±60° from vertical for wider spread -->
+      <line x1="53.5" y1="46" x2="49" y2="43.5" stroke="#f1b31c" stroke-linecap="round" stroke-width="1.5"/>
+      <line x1="53.5" y1="46" x2="53.5" y2="40" stroke="#f1b31c" stroke-linecap="round" stroke-width="1.5"/>
+      <line x1="53.5" y1="46" x2="58" y2="43.5" stroke="#f1b31c" stroke-linecap="round" stroke-width="1.5"/>
+      <!-- Left maple leaf: rotated -60°, scale 0.30 for better definition -->
+      <g transform="translate(47,42) rotate(-60) scale(0.30) translate(-36,-33.5)">
+        <polyline fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" points="36,41 42.8,41 42,39 46,35 46,32 43,32 39,36 39,29 36,26"/>
+        <polyline fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" points="36,41 29.2,41 30,39 26,35 26,32 29,32 33,36 33,29 36,26"/>
+      </g>
+      <!-- Center maple leaf: upright, scale 0.32 (slightly taller for prominence) -->
+      <g transform="translate(53.5,37.5) scale(0.32) translate(-36,-33.5)">
+        <polyline fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" points="36,41 42.8,41 42,39 46,35 46,32 43,32 39,36 39,29 36,26"/>
+        <polyline fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" points="36,41 29.2,41 30,39 26,35 26,32 29,32 33,36 33,29 36,26"/>
+      </g>
+      <!-- Right maple leaf: rotated +60°, scale 0.30 for better definition -->
+      <g transform="translate(60,42) rotate(60) scale(0.30) translate(-36,-33.5)">
+        <polyline fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" points="36,41 42.8,41 42,39 46,35 46,32 43,32 39,36 39,29 36,26"/>
+        <polyline fill="#f1b31c" stroke="#f1b31c" stroke-linecap="round" stroke-linejoin="round" stroke-width="3" points="36,41 29.2,41 30,39 26,35 26,32 29,32 33,36 33,29 36,26"/>
+      </g>
+    </g>
+    <!-- Shield outline on top -->
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M44,27 H63 V46 Q53.5,53 44,46 Z"/>
+  </g>
+  <g id="line">
+    <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>
+  </g>
+</svg>


### PR DESCRIPTION
This PR adds the [flag of Ontario](https://en.wikipedia.org/wiki/Flag_of_Ontario) as a subnational flag, because that is where I live.

The original draft was created with an LLM (Claude 4.5 Sonnet in Cline) based on the [Bermuda flag](https://en.wikipedia.org/wiki/Flag_of_Bermuda) which is also a Red Ensign. AI did a terrible job on the crest, so I had to manually edit the proportions of the leafs/St George's cross. 

The flag uses the shaded versions of all colours for consistency with the Bermuda flag and because the light green/yellow look terrible in the crest. The crest is also positioned higher up, so that it looks smaller, similar to depictions of the flag of Ontario I've seen online.