### PR TITLE
Update Ukrainian flag colors per DSTU 4512:2006

### DIFF
--- a/src/flags/country-flag/1F1FA-1F1E6.svg
+++ b/src/flags/country-flag/1F1FA-1F1E6.svg
@@ -7,8 +7,8 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <rect x="5" y="17" width="62" height="38" fill="#005BBB"/>
-    <rect x="5" y="36" width="62" height="19" fill="#FFD500"/>
+    <rect x="5" y="17" width="62" height="38" fill="#1e50a0"/>
+    <rect x="5" y="36" width="62" height="19" fill="#fcea2b"/>
   </g>
   <g id="line">
     <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>

--- a/src/flags/country-flag/1F1FA-1F1E6.svg
+++ b/src/flags/country-flag/1F1FA-1F1E6.svg
@@ -7,8 +7,8 @@
     <circle cx="36" cy="36" r="29" fill="none" stroke="#00a5ff" stroke-miterlimit="10" stroke-width="0.1"/>
   </g>
   <g id="color">
-    <rect x="5" y="17" width="62" height="38" fill="#61b2e4"/>
-    <rect x="5" y="36" width="62" height="19" fill="#fcea2b"/>
+    <rect x="5" y="17" width="62" height="38" fill="#005BBB"/>
+    <rect x="5" y="36" width="62" height="19" fill="#FFD500"/>
   </g>
   <g id="line">
     <rect x="5" y="17" width="62" height="38" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"/>


### PR DESCRIPTION
Updated the blue and yellow hex codes of the Ukrainian flag to strictly comply with the national standard DSTU 4512:2006:

- Blue: PANTONE 2935 C (#005BBB)
- Yellow: PANTONE Yellow C (#FFD500)